### PR TITLE
Use patterns/signatures to grab data from memory

### DIFF
--- a/GC-SampClient/GC-SampClient.vcxproj
+++ b/GC-SampClient/GC-SampClient.vcxproj
@@ -34,6 +34,7 @@
     <ClInclude Include="Config\simpleini.h" />
     <ClInclude Include="Hooks\Hooks.h" />
     <ClInclude Include="Hook\Hook.h" />
+    <ClInclude Include="Hook\Memory.h" />
     <ClInclude Include="Hook\Pattern.h" />
     <ClInclude Include="Misc\debug.h" />
     <ClInclude Include="SDK\SAMP.h" />

--- a/GC-SampClient/GC-SampClient.vcxproj
+++ b/GC-SampClient/GC-SampClient.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="Hooks\Hooks.cpp" />
     <ClCompile Include="Hooks\SendMessage_Hooked.cpp" />
     <ClCompile Include="Hook\Hook.cpp" />
+    <ClCompile Include="Hook\Pattern.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="SDK\SAMP.cpp" />
   </ItemGroup>
@@ -33,6 +34,7 @@
     <ClInclude Include="Config\simpleini.h" />
     <ClInclude Include="Hooks\Hooks.h" />
     <ClInclude Include="Hook\Hook.h" />
+    <ClInclude Include="Hook\Pattern.h" />
     <ClInclude Include="Misc\debug.h" />
     <ClInclude Include="SDK\SAMP.h" />
   </ItemGroup>

--- a/GC-SampClient/GC-SampClient.vcxproj.filters
+++ b/GC-SampClient/GC-SampClient.vcxproj.filters
@@ -69,5 +69,8 @@
     <ClInclude Include="Hook\Pattern.h">
       <Filter>Hook</Filter>
     </ClInclude>
+    <ClInclude Include="Hook\Memory.h">
+      <Filter>Hook</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/GC-SampClient/GC-SampClient.vcxproj.filters
+++ b/GC-SampClient/GC-SampClient.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="Config\Config.cpp">
       <Filter>Config</Filter>
     </ClCompile>
+    <ClCompile Include="Hook\Pattern.cpp">
+      <Filter>Hook</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Hook">
@@ -62,6 +65,9 @@
     </ClInclude>
     <ClInclude Include="Config\Config.h">
       <Filter>Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Hook\Pattern.h">
+      <Filter>Hook</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/GC-SampClient/Hook/Memory.h
+++ b/GC-SampClient/Hook/Memory.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <Windows.h>
+#include <optional>
+
+namespace Memory
+{
+	namespace Internal
+	{
+		inline int filter(unsigned int code, struct _EXCEPTION_POINTERS * ep)
+		{
+			return code == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH;
+		}
+
+		template<typename T>
+		inline T readMemory(DWORD addr, bool & success)
+		{
+			__try
+			{
+				auto val = *(T *)(addr);
+				success = true;
+				return val;
+			}
+			__except (filter(GetExceptionCode(), GetExceptionInformation()))
+			{
+				success = false;
+			}
+
+			return T();
+		}
+	}
+
+	template<typename T>
+	inline std::optional<T> readMemory(uintptr_t addr)
+	{
+		bool success = false;
+		auto t = Internal::readMemory<T>(addr, success);
+
+		return success ? std::optional<T>(t) : std::optional<T>();
+	}
+}

--- a/GC-SampClient/Hook/Pattern.cpp
+++ b/GC-SampClient/Hook/Pattern.cpp
@@ -1,0 +1,31 @@
+#include "Pattern.h"
+
+Pattern::Pattern(HANDLE process, HMODULE module_handle)
+{
+	MODULEINFO module_info = { NULL };
+
+	GetModuleInformation(process, module_handle, &module_info, sizeof(MODULEINFO));
+
+	moduleBase = reinterpret_cast<DWORD>(module_info.lpBaseOfDll);
+	moduleSize = module_info.SizeOfImage;
+}
+
+DWORD Pattern::Find(char * pattern, char * mask)
+{
+	DWORD patternLength = static_cast<DWORD>(strlen(mask));
+
+	for (DWORD i = 0; i < moduleSize - patternLength; i++)
+	{
+		bool found = true;
+		for (DWORD j = 0; j < patternLength; j++)
+		{
+			found &= mask[j] == '?' || pattern[j] == *reinterpret_cast<char *>((moduleBase + i + j));
+		}
+
+		if (found)
+		{
+			return moduleBase + i;
+		}
+	}
+	return NULL;
+}

--- a/GC-SampClient/Hook/Pattern.h
+++ b/GC-SampClient/Hook/Pattern.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <Windows.h>
+#include <Psapi.h>
+
+class Pattern
+{
+private:
+	DWORD moduleBase;
+	DWORD moduleSize;
+
+public:
+	Pattern(HANDLE process, HMODULE module_handle);
+	DWORD Find(char * pattern, char * mask);
+};

--- a/GC-SampClient/Hooks/Hooks.cpp
+++ b/GC-SampClient/Hooks/Hooks.cpp
@@ -1,4 +1,5 @@
 #include "Hooks.h"
+#include "../Hook/Pattern.h"
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include "../SDK/SAMP.h"
@@ -6,8 +7,22 @@
 
 bool Hooks::Initialize()
 {
-	Hooks::sendMessageHook = Hook(reinterpret_cast<BYTE*>(SAMP::base) + SAMP::FN_SEND_MESSAGE_OFFSET, reinterpret_cast<BYTE*>(Hooks::SendMessage_Hooked), 6U);
+	Pattern pat(GetCurrentProcess(), reinterpret_cast<HMODULE>(SAMP::base));
+
+	DWORD SMAddr = NULL;
+
+	while (SMAddr == NULL) 
+	{
+		SMAddr = pat.Find(
+			(char *)"\x64\xA1\x00\x00\x00\x00\x6A\xFF\x68\x00\x00\x00\x00\x50\x64\x89\x25\x00\x00\x00\x00\x81\xEC\x00\x00\x00\x00\x53\x56\x8B\xB4\x24\x00\x00\x00\x00\x8B\xC6",
+			(char *)"xx????xxx????xxxx????xx????xxxxx????xx"
+		);
+		Sleep(500);
+	}
+	
+	Hooks::sendMessageHook = Hook(reinterpret_cast<void *>(SMAddr), reinterpret_cast<BYTE *>(Hooks::SendMessage_Hooked), 6U);
 	Hooks::SendMessageOriginal = reinterpret_cast<Hooks::fnSendMessage>(Hooks::sendMessageHook.PlaceTrampoline());
+
 	return true;
 }
 

--- a/GC-SampClient/SDK/Samp.cpp
+++ b/GC-SampClient/SDK/Samp.cpp
@@ -8,7 +8,7 @@
 bool SAMP::Initialize()
 {
 	SAMP::base = GetModuleHandleA("samp.dll");
-	return true;
+	return !!SAMP::base;
 }
 
 

--- a/GC-SampClient/SDK/Samp.cpp
+++ b/GC-SampClient/SDK/Samp.cpp
@@ -2,15 +2,19 @@
 #include <string.h>
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <iomanip>
 #include <sstream>
 #include "../Hook/Pattern.h"
+#include "../Hook/Memory.h"
+
+#define CHECK_OFFSET(X, RET, TYPE) \
+	if (auto val = Memory::readMemory<TYPE>(X)) { if (*val == 0) return RET; } else return RET;
 
 bool SAMP::Initialize()
 {
 	SAMP::base = GetModuleHandleA("samp.dll");
 	return !!SAMP::base;
 }
-
 
 bool SAMP::AddMessageToChat(const char * message, size_t color)
 {
@@ -30,6 +34,8 @@ bool SAMP::AddMessageToChat(const char * message, size_t color)
 	if (ACMAddr) {
 		DWORD dwCallAddr = *(DWORD *)(ACMAddr + 0xD) + ACMAddr + 0xD + 0x4;
 		DWORD dwInfo = *(DWORD *)(ACMAddr + 0x2);
+
+		CHECK_OFFSET(dwInfo, false, DWORD)
 
 		__asm mov edx, dword ptr[dwInfo]
 		__asm mov eax, [edx]

--- a/GC-SampClient/SDK/Samp.cpp
+++ b/GC-SampClient/SDK/Samp.cpp
@@ -17,7 +17,7 @@ bool SAMP::AddMessageToChat(const char * message, size_t color)
 	Pattern pat(GetCurrentProcess(), reinterpret_cast<HMODULE>(SAMP::base));
 
 	std::ostringstream convColor;
-	convColor << std::hex << color;
+	convColor << std::hex << std::setw(6) << std::setfill('0') << color;
 
 	std::string textMsg = "{" + convColor.str() + "}" + message;
 	const char * cText = textMsg.c_str();

--- a/GC-SampClient/SDK/Samp.cpp
+++ b/GC-SampClient/SDK/Samp.cpp
@@ -2,28 +2,46 @@
 #include <string.h>
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <sstream>
+#include "../Hook/Pattern.h"
 
 bool SAMP::Initialize()
 {
 	SAMP::base = GetModuleHandleA("samp.dll");
-	if (SAMP::base == nullptr)
-		return false;
-	SAMP::chatInfo = *(void**)(reinterpret_cast<uintptr_t>(SAMP::base) + SAMP::ST_CHAT_INFO_OFFSET);
-	if (SAMP::chatInfo == nullptr)
-		return false;
-	SAMP::AddMessageToChatOriginal = reinterpret_cast<fnAddMessageToChat>(reinterpret_cast<uintptr_t>(SAMP::base) + SAMP::FN_ADD_TO_CHAT_OFFSET);
 	return true;
 }
 
 
-bool SAMP::AddMessageToChat(const char* message, size_t color)
+bool SAMP::AddMessageToChat(const char * message, size_t color)
 {
-	size_t chunkPtr = 0;
-	while (strlen(message) > SAMP::ADD_TO_CHAT_CHUNK_SIZE + chunkPtr)
-	{
-		SAMP::AddMessageToChatOriginal(chatInfo, 8, message + chunkPtr, nullptr, color, 0);
-		chunkPtr += SAMP::ADD_TO_CHAT_CHUNK_SIZE;
+	Pattern pat(GetCurrentProcess(), reinterpret_cast<HMODULE>(SAMP::base));
+
+	std::ostringstream convColor;
+	convColor << std::hex << color;
+
+	std::string textMsg = "{" + convColor.str() + "}" + message;
+	const char * cText = textMsg.c_str();
+
+	auto ACMAddr = pat.Find(
+		(char *)"\x8B\x15\x00\x00\x00\x00\x68\x00\x00\x00\x00\x52\xE8\x00\x00\x00\x00\x83\xC4\x08\x5F\x5E",
+		(char *)"xx????x????xx????xxxxx"
+	);
+
+	if (ACMAddr) {
+		DWORD dwCallAddr = *(DWORD *)(ACMAddr + 0xD) + ACMAddr + 0xD + 0x4;
+		DWORD dwInfo = *(DWORD *)(ACMAddr + 0x2);
+
+		__asm mov edx, dword ptr[dwInfo]
+		__asm mov eax, [edx]
+		__asm push cText
+		__asm push eax
+		__asm call dwCallAddr
+		__asm add esp, 8
 	}
-	SAMP::AddMessageToChatOriginal(chatInfo, 8, message + chunkPtr, nullptr, color, 0);
+	else {
+		// Error handling maybe?
+		return false;
+	}
+
 	return true;
 }

--- a/GC-SampClient/SDK/Samp.h
+++ b/GC-SampClient/SDK/Samp.h
@@ -3,17 +3,7 @@
 
 namespace SAMP
 {
-	typedef void(__thiscall* fnAddMessageToChat) (void* object, uint32_t messageType, const char* text, const char* prefix, uint32_t textColor, uint32_t prefixColor);
-
-	constexpr uintptr_t FN_SEND_MESSAGE_OFFSET = 0x57F0U;
-	constexpr uintptr_t FN_ADD_TO_CHAT_OFFSET = 0x64010U;
-	constexpr uintptr_t ST_CHAT_INFO_OFFSET = 0x21A0E4U;
-
-	constexpr size_t ADD_TO_CHAT_CHUNK_SIZE = 86;
-
 	inline void* base;
-	inline void* chatInfo;
-	inline fnAddMessageToChat AddMessageToChatOriginal;
 
 	bool Initialize();
 	bool AddMessageToChat(const char* message, size_t color = 0x00FF00U);

--- a/GC-SampClient/main.cpp
+++ b/GC-SampClient/main.cpp
@@ -13,6 +13,10 @@ void Entry(HMODULE hModule)
 {
 #ifdef DEBUG_MODE
 	ALLOC_CONSOLE();
+
+	// check for game initialization first
+	while (!*reinterpret_cast<int *>(0xB6F5F0)) Sleep(50);
+
 #endif	
 	if (Config::Load("gc_config.ini") == false)
 	{

--- a/GC-SampClient/main.cpp
+++ b/GC-SampClient/main.cpp
@@ -20,13 +20,19 @@ void Entry(HMODULE hModule)
 #endif	
 	if (Config::Load("gc_config.ini") == false)
 	{
-		Sleep(100);
-	}
-
-	if (Config::Load("gc_config.ini") == false)
-	{
+#ifdef DEBUG_MODE
+		OUTPUT_ERROR("Failed loading config.ini, check your GTA folder.", 0xC00000);
+		system("pause");
+		FREE_CONSOLE();
+#endif
 		SAMP::AddMessageToChat("[ERROR] Failed loading config.ini, check your GTA folder.", 0xC00000);
 		FreeLibraryAndExitThread(hModule, 0);
+		return;
+	}
+
+	while (SAMP::Initialize() != true)
+	{
+		Sleep(100);
 	}
 
 	if (GNet::Network::Initialize() == false)
@@ -39,6 +45,11 @@ void Entry(HMODULE hModule)
 
 	if (Hooks::Initialize() == false)
 	{
+#ifdef DEBUG_MODE
+		OUTPUT_ERROR("Failed placing hooks");
+		system("pause");
+		FREE_CONSOLE();
+#endif
 		SAMP::AddMessageToChat("[ERROR] GChat failed placing hooks.", 0xC00000);
 		GNet::Network::Shutdown();
 		FreeLibraryAndExitThread(hModule, 0);
@@ -62,14 +73,12 @@ void Entry(HMODULE hModule)
 			std::string loginRequest = "/login " + Config::username + " " + Config::password;
 			Client::Send(loginRequest.c_str());
 		}
-	}
-
-	/*
-	while (true)
-	{
+		while (true)
+		{
 			if (GetAsyncKeyState(VK_END))
 				break;
-		Sleep(150);
+			Sleep(150);
+		}
 	}
 
 	if (Client::connected == true)
@@ -79,7 +88,12 @@ void Entry(HMODULE hModule)
 	SAMP::AddMessageToChat("GChat shut down.");
 	Client::Shutdown();
 	Hooks::Shutdown();
-	GNet::Network::Shutdown();*/
+	GNet::Network::Shutdown();
+
+#ifdef DEBUG_MODE
+	FREE_CONSOLE();
+#endif
+	FreeLibraryAndExitThread(hModule, 0);
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
@@ -91,7 +105,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 		HANDLE hThread = nullptr;
 		hThread = CreateThread(0, 0, (LPTHREAD_START_ROUTINE)Entry, hModule, 0, 0);
 		if (hThread)
-			CloseHandle(hThread); // Thread so it doesn't block the gamethread
+			CloseHandle(hThread);
 		break;
 	}
 	case DLL_THREAD_ATTACH:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 fl1k
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
-# GChat
+# GChat - Global Chat
 GChat is a multi-client chat application with a login system. Packets are sent using a TCP connection. 
 It supports 2 types of clients, a chat client and a SAMP (0.3.7 R1) client. Every message that starts with a dot '.' will be forwarded to the GChat Server.
 
 It includes GNet library which is a wrapper around system's sockets.
+
+## FEATURES
+- Login system (local SQLite database)
+- Privilege system (Admin(2), Moderator(1), Default(0))
+- Commands based on privilege
+  *) default commands: help, list, logout, login, disconnect
+  *) staff commands: adduser, removeuser, kick
+- Chat between gameservers, games, operating systems
+- Chat competely private, only visible to those on the same GServer! Ideal for groups and clans, and communities spanning on different servers
+
+## SERVER SETUP
+*) If LAN server go to step 2)
+1) Open 9920 port for TCP connections
+2) Run the server, it will prompt you to enter the first user (you) and it'll be given Admin privilege.
+3) You may login using the crediantals you provided, using the /adduser command you may add new users
+
+## SAMP CLIENT SETUP ( 0.3.7 R1 supported only )
+1) Place .asi file in your SAMP directory. Once you run the game a gc-config.ini file will be created, in this config file you will put the ip, port, your username, your password, if the server is using a hostname (URL - google.com) you will change useHostname to true.
+2) Run the game, it should say "GChat initialized" 
+3) Use dot ('.') before your messages to forward them to the GServer you're connected on

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ It supports 2 types of clients, a chat client and a SAMP (0.3.7 R1) client. Ever
 
 It includes GNet library which is a wrapper around system's sockets.
 
+
 ## FEATURES
 - Login system (local SQLite database)
 - Privilege system (Admin(2), Moderator(1), Default(0))
@@ -13,11 +14,13 @@ It includes GNet library which is a wrapper around system's sockets.
 - Chat between gameservers, games, operating systems
 - Chat competely private, only visible to those on the same GServer! Ideal for groups and clans, and communities spanning on different servers
 
+
 ## SERVER SETUP
 - If LAN server go to step 2)
 1) Open 9920 port for TCP connections
 2) Run the server, it will prompt you to enter the first user (you) and it'll be given Admin privilege.
 3) You may login using the crediantals you provided, using the /adduser command you may add new users
+
 
 ## SAMP CLIENT SETUP ( 0.3.7 R1 supported only )
 1) Place .asi file in your SAMP directory. Once you run the game a gc-config.ini file will be created, in this config file you will put the ip, port, your username, your password, if the server is using a hostname (URL - google.com) you will change useHostname to true.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# GChat
+GChat is a multi-client chat application with a login system. Packets are sent using a TCP connection. 
+It supports 2 types of clients, a chat client and a SAMP client. Every message that starts with a dot '.' will be forwarded to the GChat Server.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GChat
 GChat is a multi-client chat application with a login system. Packets are sent using a TCP connection. 
-It supports 2 types of clients, a chat client and a SAMP client. Every message that starts with a dot '.' will be forwarded to the GChat Server.
+It supports 2 types of clients, a chat client and a SAMP (0.3.7 R1) client. Every message that starts with a dot '.' will be forwarded to the GChat Server.
 
 It includes GNet library which is a wrapper around system's sockets.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # GChat
 GChat is a multi-client chat application with a login system. Packets are sent using a TCP connection. 
 It supports 2 types of clients, a chat client and a SAMP client. Every message that starts with a dot '.' will be forwarded to the GChat Server.
+
+It includes GNet library which is a wrapper around system's sockets.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It includes GNet library which is a wrapper around system's sockets.
 - Chat competely private, only visible to those on the same GServer! Ideal for groups and clans, and communities spanning on different servers
 
 ## SERVER SETUP
-*) If LAN server go to step 2)
+- If LAN server go to step 2)
 1) Open 9920 port for TCP connections
 2) Run the server, it will prompt you to enter the first user (you) and it'll be given Admin privilege.
 3) You may login using the crediantals you provided, using the /adduser command you may add new users
@@ -23,3 +23,5 @@ It includes GNet library which is a wrapper around system's sockets.
 1) Place .asi file in your SAMP directory. Once you run the game a gc-config.ini file will be created, in this config file you will put the ip, port, your username, your password, if the server is using a hostname (URL - google.com) you will change useHostname to true.
 2) Run the game, it should say "GChat initialized" 
 3) Use dot ('.') before your messages to forward them to the GServer you're connected on
+
+https://www.youtube.com/watch?v=Ojak_z0-_9M


### PR DESCRIPTION
This PR adds pattern scanning functionality and removes hardcoded addresses/offsets which was limiting it to SA-MP 0.3.7 R1 only, now it should theoretically work on all of them, tested it with R4 and it was working

Both AddChatMessage call and SendMessage hook are now using pattern scanning to be found on memory.

#### NOTE: I haven't tested it in your plugin yet, but it's working in my sample, I can't do testing myself right now as I don't have access to my windows machine directly, I did this PR by connecting to my laptop at home using AnyDesk, so it's a pain to do it...